### PR TITLE
Query path tables

### DIFF
--- a/indralab_web_templates/indralab_web_templates/templates/path_macros.html
+++ b/indralab_web_templates/indralab_web_templates/templates/path_macros.html
@@ -124,10 +124,15 @@ path_list = [{"path": "A-X1-X2-B",
 
 For failing test, it's just an error message e.g.: "No paths found"
 #}
-{% macro detailed_paths(path_list, card_header, model, model_type, formatted_names, test_status='Fail', card_id=None, table_id=None) -%}
+{% macro detailed_paths(path_list, card_header, model, model_type, formatted_names, test_status='Fail', card_id=None, table_id=None, is_query_page=false) -%}
   <div class="card" {% if card_id %}id="{{ card_id }}"{% endif %}>
     <div class="card-header">
-      <h4 class="my-0 font-weight-normal">Test: "
+      <h4 class="my-0 font-weight-normal">
+      {% if is_query_page %}
+        Query
+      {% else %}
+        Test
+      {% endif %}: "
       {% if card_header|length == 2 %}
         {% set href, text = card_header %}
         <a href="{{ href }}" class="stmt-dblink" target="_blank">{{ text }}</a>
@@ -198,6 +203,8 @@ For failing test, it's just an error message e.g.: "No paths found"
     <p>The test passed, but can't be shown because of the following condition: {{ msg }}</p>
   {% elif status|lower == 'n_a' %}
     <p>The test is not applicable for the current model or model type ({{ msg }})</p>
+  {% elif status|lower == 'query' %}
+    <p>The query does not have a stashed result. (query hash: {{ msg }})</p>
   {% endif %}
   <p>To see more information about tests, see the <a href="https://emmaa.readthedocs.io/en/latest/dashboard/response_codes.html">documentation</a>.</p>
 {%- endmacro %}

--- a/indralab_web_templates/indralab_web_templates/templates/path_macros.html
+++ b/indralab_web_templates/indralab_web_templates/templates/path_macros.html
@@ -194,8 +194,10 @@ For failing test, it's just an error message e.g.: "No paths found"
 {% macro failing_test_card_body(msg, status) -%}
   {% if status|lower == 'fail' %}
     <p>The test failed with the following code: {{ msg }}</p>
-  {% else %}
+  {% elif status|lower == 'pass' %}
     <p>The test passed, but can't be shown because of the following condition: {{ msg }}</p>
+  {% elif status|lower == 'n_a' %}
+    <p>The test is not applicable for the current model or model type ({{ msg }})</p>
   {% endif %}
   <p>To see more information about tests, see the <a href="https://emmaa.readthedocs.io/en/latest/dashboard/response_codes.html">documentation</a>.</p>
 {%- endmacro %}

--- a/indralab_web_templates/indralab_web_templates/templates/path_macros.html
+++ b/indralab_web_templates/indralab_web_templates/templates/path_macros.html
@@ -148,7 +148,7 @@ For failing test, it's just an error message e.g.: "No paths found"
       {% if test_status|lower == 'pass' and path_list is not string %}
         {{ detailed_paths_table_contents(path_list, table_id) }}
       {% else %}
-        {{ failing_test_card_body(path_list, test_status) }}
+        {{ failing_test_card_body(path_list, test_status, is_query_page) }}
       {% endif %}
     </div>
   </div>
@@ -196,15 +196,20 @@ For failing test, it's just an error message e.g.: "No paths found"
   </table>
 {%- endmacro %}
 
-{% macro failing_test_card_body(msg, status) -%}
+{% macro failing_test_card_body(msg, status, is_query_page) -%}
+  {% if is_query_page %}
+    {% set st = 'query' %}
+  {% else %}
+    {% set st = 'test' %}
+  {% endif %}
   {% if status|lower == 'fail' %}
-    <p>The test failed with the following code: {{ msg }}</p>
+    <p>The {{ st }} failed with the following code: {{ msg }}</p>
   {% elif status|lower == 'pass' %}
-    <p>The test passed, but can't be shown because of the following condition: {{ msg }}</p>
+    <p>The {{ st }} passed, but can't be shown because of the following condition: {{ msg }}</p>
   {% elif status|lower == 'n_a' %}
-    <p>The test is not applicable for the current model or model type ({{ msg }})</p>
+    <p>The {{ st }} is not applicable for the current model or model type ({{ msg }})</p>
   {% elif status|lower == 'query' %}
-    <p>The query does not have a stashed result. (query hash: {{ msg }})</p>
+    <p>The {{ st }} does not have a stashed result. ({{ msg }})</p>
   {% endif %}
   <p>To see more information about tests, see the <a href="https://emmaa.readthedocs.io/en/latest/dashboard/response_codes.html">documentation</a>.</p>
 {%- endmacro %}

--- a/indralab_web_templates/indralab_web_templates/templates/path_macros.html
+++ b/indralab_web_templates/indralab_web_templates/templates/path_macros.html
@@ -60,6 +60,7 @@
   {% for link_address, link_text, evid_text in row %}
     {# Pass: <i class="fas fa-check"></i>#}
     {# Fail: <i class="fas fa-times"></i>#}
+    {# Not Applicable: <i class="fas fa-ban"></i> #}
     {# See more at:#}
     {# https://fontawesome.com/icons?d=gallery#}
     {% if link_text == 'Pass' %}
@@ -74,8 +75,14 @@
           <i class="fas fa-times"></i>
         </a>
       </td>
-    {% elif merge and loop.length == 1%}
-        <td colspan="2" style="text-align:center; font-weight: bold;">{{ link_text }}</td>
+    {% elif link_text == 'n_a' %}
+      <td style="text-align: center">
+        <a href="{{ link_address }}" title="{{ evid_text }}" target="_blank">
+          <i class="fas fa-ban"></i>
+        </a>
+      </td>
+    {% elif merge and loop.length == 1 %}
+      <td colspan="2" style="text-align:center; font-weight: bold;">{{ link_text }}</td>
     {% else %}
       <td>
       {% if link_address and evid_text %}

--- a/indralab_web_templates/indralab_web_templates/templates/path_macros.html
+++ b/indralab_web_templates/indralab_web_templates/templates/path_macros.html
@@ -39,10 +39,10 @@
     {% if headers %}
     <thead class="table-head">
     {% for header in headers %}
-    {% if "Test" in headers %}
-      <th {% if header != "Test" and header != "Top Path" %}style="width: 15%; text-align: center"{% endif %}>{{ header }}</th>
+    {% if "Test" in headers or "Query" in headers %}
+      <th {% if header not in ["Test", "Top Path", "Query", "Model"] %}style="width: 15%; text-align: center"{% endif %}>{{ header }}</th>
     {% else %}
-      <th>{{ header }}</th>
+      <th style="text-align: center">{{ header }}</th>
     {% endif %}
     {% endfor %}
     </thead>
@@ -60,7 +60,7 @@
   {% for link_address, link_text, evid_text in row %}
     {# Pass: <i class="fas fa-check"></i>#}
     {# Fail: <i class="fas fa-times"></i>#}
-    {# Not Applicable: <i class="fas fa-ban"></i> #}
+    {# N/A: <i class="fas fa-ban"></i> #}
     {# See more at:#}
     {# https://fontawesome.com/icons?d=gallery#}
     {% if link_text == 'Pass' %}


### PR DESCRIPTION
This PR makes slight changes to the web templates to allow for more options in the look of the tables. Specific changes:

- Added a new icon for when a test or query is not applicable
- The detailed paths macro is now showing "query" or "test" depending on when it is appropriate