### PR TITLE
Simplify table header

### DIFF
--- a/indralab_web_templates/indralab_web_templates/templates/path_macros.html
+++ b/indralab_web_templates/indralab_web_templates/templates/path_macros.html
@@ -20,22 +20,10 @@
   </div>
 {%- endmacro %}
 
-{% macro path_card(path_list, card_header, card_id, table_headers=[], table_id=None, merge=false, url=None, show_all=False, subscription=False) -%}
+{% macro path_card(path_list, card_header, card_id, table_headers=[], table_id=None, merge=false, url=None) -%}
   <div class="card" id="{{ card_id }}">
     <div class="card-header">
-      {% if show_all %}
-      <h4 class="my-0 font-weight-normal">{{ card_header }}<button class="btn btn-outline-secondary" onClick='window.open("{{ show_all }}", target="_blank")' style="position: absolute; right: 10px; top: 1.1%" type="button">View All Statements</button></h4>
-      {% elif subscription %}
-        {% set logged_in, subscribe, url = subscription %}
-        {% if logged_in %}
-          <h4 class="my-0 font-weight-normal">{{ card_header }}<button class="btn btn-outline-secondary" onClick="subscribe_model('{{ url }}', '{{ subscribe }}')" style="position: absolute; right: 10px; top: 1.1%" type="button">{% if subscribe %}Subscribe{% else %}Unsubscribe{% endif %}</button></h4>
-          <span><i id="model-subscription-status" style="word-break:break-word; float: right;"></i></span>
-        {% else %}
-        <h4 class="my-0 font-weight-normal" style="float: left">{{ card_header }}</h4><span style="font-size: medium; float: right">(Log in and refresh to see if you're subscribed to this model)</span>
-        {% endif %}
-      {% else %}
       <h4 class="my-0 font-weight-normal">{{ card_header }}</h4>
-      {% endif %}
     </div>
     <div class="card-body">
       {{ path_table(path_list, table_headers, table_id, merge, url) }}


### PR DESCRIPTION
This PR simplifies the `path_card` template by removing additional button conditions (they can be configured in the application directly) to avoid adding more if-else blocks. It's recommended to use `path_card` macros for standard looking cards only and use a combination of custom header and `path_table` macros otherwise.