### PR TITLE
Upgrade to flask_jwt_extended>3

### DIFF
--- a/indralab_auth_tools/indralab_auth_tools/auth.py
+++ b/indralab_auth_tools/indralab_auth_tools/auth.py
@@ -33,6 +33,12 @@ def config_auth(app):
     app.config['PROPAGATE_EXCEPTIONS'] = True
     app.config['JWT_COOKIE_CSRF_PROTECT'] = False
     app.config['EXPLAIN_TEMPLATE_LOADING'] = True
+    # Setting JWT_IDENTITY_CLAIM to 'identity' to override the new default 'sub'. This
+    # allows those with tokens still active and issued by the old deployment (which
+    # used Flask-JWT-Extended < 4) to still load the homepage of the new deployment. If
+    # this is not done, a user with an active old JWT will be greeted with an error
+    # that refers to a missing key ('identity' or 'sub'). See more at:
+    # https://flask-jwt-extended.readthedocs.io/en/stable/v4_upgrade_guide.html#encoded-jwt-changes-important
     app.config['JWT_IDENTITY_CLAIM'] = 'identity'
     SC = SimpleCookie()
     jwt = JWTManager(app)

--- a/indralab_auth_tools/indralab_auth_tools/auth.py
+++ b/indralab_auth_tools/indralab_auth_tools/auth.py
@@ -33,6 +33,7 @@ def config_auth(app):
     app.config['PROPAGATE_EXCEPTIONS'] = True
     app.config['JWT_COOKIE_CSRF_PROTECT'] = False
     app.config['EXPLAIN_TEMPLATE_LOADING'] = True
+    app.config['JWT_IDENTITY_CLAIM'] = 'identity'
     SC = SimpleCookie()
     jwt = JWTManager(app)
 

--- a/indralab_auth_tools/indralab_auth_tools/auth.py
+++ b/indralab_auth_tools/indralab_auth_tools/auth.py
@@ -5,7 +5,7 @@ from functools import wraps
 
 from http.cookies import SimpleCookie
 
-from flask_jwt_extended import jwt_optional, get_jwt_identity, \
+from flask_jwt_extended import jwt_required, get_jwt_identity, \
     create_access_token, set_access_cookies, unset_jwt_cookies, JWTManager
 
 from flask import Blueprint, jsonify, request, redirect
@@ -46,7 +46,7 @@ def config_auth(app):
 
 
 def auth_wrapper(func):
-    @jwt_optional
+    @jwt_required(optional=True)
     @wraps(func)
     def with_auth_log():
         start_fresh()
@@ -204,8 +204,8 @@ def logout(auth_details, user_identity):
 def resolve_auth(query, failure_reason=None):
     """Get the roles for the current request, either by JWT or API key.
 
-    If by API key, the key must be in the query. If by JWT, @jwt_optional or
-    similar must wrap the calling function.
+    If by API key, the key must be in the query. If by JWT,
+    @jwt_required(optional=True) or similar must wrap the calling function.
 
     If the reason for credentials failing is of interest, you can pass an empty
     dictionary to `failure_reason`. If there is an auth problem, it will be

--- a/indralab_auth_tools/setup.py
+++ b/indralab_auth_tools/setup.py
@@ -9,7 +9,7 @@ def main():
         author_email="patrick_greene@hms.harvard.edu",
         url="http://github.com/indralab/ui_util",
         packages=find_packages(),
-        install_requires=["flask-jwt-extended", "flask", "sqlalchemy", "scrypt"],
+        install_requires=["flask-jwt-extended", "flask", "sqlalchemy<2", "scrypt"],
         include_package_data=True,
         version="1.0.0",
     )

--- a/indralab_auth_tools/setup.py
+++ b/indralab_auth_tools/setup.py
@@ -9,7 +9,7 @@ def main():
         author_email="patrick_greene@hms.harvard.edu",
         url="http://github.com/indralab/ui_util",
         packages=find_packages(),
-        install_requires=["flask-jwt-extended<4.0.0", "flask", "sqlalchemy", "scrypt"],
+        install_requires=["flask-jwt-extended", "flask", "sqlalchemy", "scrypt"],
         include_package_data=True,
         version="1.0.0",
     )


### PR DESCRIPTION
Update usage of flask_jwt_extended decorator to be compatible with flask_jwt_extended>3, which is a requirement for using Flask>=3.

See sorgerlab/indra#1448.

Todo:

- [x] Test with CoGEx - see https://github.com/gyorilab/indra_cogex/pull/172
- [x] Test with EMMAA - see https://github.com/gyorilab/emmaa/pull/280
- [x] Test with new indra db deployment - see https://github.com/gyorilab/indra_db/pull/222